### PR TITLE
bugfix: Settings do not load

### DIFF
--- a/modules/RepConvGRC.js
+++ b/modules/RepConvGRC.js
@@ -1986,10 +1986,10 @@ function _RepConvGRC() {
                 ),
             resEmo = $('<fieldset/>', {'style': 'float:right; width:370px; min-height: 250px;'})
 
-            var chbx = {}
-            $.each(RepConv.sChbxs, function(opt, optData){
-                chbx[opt] = genCheckBox(opt, RepConv.settings[opt], optData.label)
-            })
+        var chbx = {}
+        $.each(RepConv.sChbxs, function(opt, optData){
+            chbx[opt] = genCheckBox(opt, RepConv.settings[opt], optData.label)
+        })
 
             // cPower = genCheckBox(RepConv.CookiePower, RepConv.active.power, 'CHKPOWERNAME'),
             // cFTabs = genCheckBox(RepConv.CookieForumTabs, RepConv.active.ftabs, 'CHKFORUMTABS'),
@@ -2004,6 +2004,7 @@ function _RepConvGRC() {
 
             // cbBuPo = genCheckBox(RepConv.Cookie+'_bupo', RepConv.settings[RepConv.Cookie+'_bupo'], 'CHKBUPO'),
 
+        var
             cSLoop = genCheckBox('GRCRTsoundLoop',RepConv.active.sounds.loop, 'CHKSOUNDLOOP'),
             cSMute = genCheckBox('GRCRTsoundMute',RepConv.active.sounds.mute, 'POPSOUNDMUTE'),
             sStats = $('<div/>',{'id':'statsGRC2Sel','class':'dropdown default','style':'margin-left:5px;width: 150px;'})


### PR DESCRIPTION
## Pull Request type
- [X] Bugfix
- [ ] Performance optimization
- [ ] Refactoring or styling (code change that is neither bugfix nor performance improvement)
- [ ] New feature
- [ ] Documentation changes


### Short description of what it does:
The "use strict" tag requires each variable to be defined, and the cSloop variable was used after the $.each loop (there was no "var" before it was used).