### PR TITLE
Update RepConvGRC.js

### DIFF
--- a/modules/RepConvGRC.js
+++ b/modules/RepConvGRC.js
@@ -2445,7 +2445,7 @@ function _RepConvGRC() {
         (RCGP.getJQElement()).find($('#fto_town_list li.town' + Game.townId)).attr('style', 'border-right: 5px solid green');
         if (((RCGP.getJQElement()).find($('#fto_town_list li.town' + Game.townId + '.active'))).length == 0 && RepConv.currTown != Game.townId) {
             RepConv.currTown = Game.townId;
-            ((RCGP.getJQElement()).find($('#fto_town_list li.town' + Game.townId))).click();
+            // ((RCGP.getJQElement()).find($('#fto_town_list li.town' + Game.townId))).click(); //This is buggy...
         }
     }
 


### PR DESCRIPTION
((RCGP.getJQElement()).find($('#fto_town_list li.town' + Game.townId))).click();

There is sometimes a delay to this line being run for some reason.

1. Open Grepolis.
2. Open farming overview
3. Farm + click another city (quickly after opening)

The current city is selected once again (due to delay). This is irritating behaviour when you try to farm quickly.

This also happens if you switch cities then farm.

I suggest to remove the feature temporarily until a fix can be made.

https://i.imgur.com/gXzGp3I.gifv